### PR TITLE
iterator implementation

### DIFF
--- a/lab3/Composite/classes/Iterator.cs
+++ b/lab3/Composite/classes/Iterator.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	 public abstract class Iterator : IEnumerator
+	{
+		object IEnumerator.Current => Current();
+		public abstract LightNode Current();
+		public abstract int Key();
+		public abstract bool MoveNext();
+		public abstract void Reset();
+	}
+}

--- a/lab3/Composite/classes/LightElementNode.cs
+++ b/lab3/Composite/classes/LightElementNode.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -6,13 +7,14 @@ using System.Threading.Tasks;
 
 namespace Composite.classes
 {
-	public class LightElementNode : LightNode
+	public class LightElementNode : LightNode, NodeAggregate
 	{
 		private string _tagName;
 		private bool _isBlock;
 		private bool _isSelfClosing;
 		private List<string> _cssClasses;
 		private List<LightNode> _children;
+		private bool _reverseDirection = false;
 
 		private Dictionary<string, List<Action>> _eventListeners = new Dictionary<string, List<Action>>();
 
@@ -106,6 +108,20 @@ namespace Composite.classes
 				if (_isBlock && sb.Length > 0) sb.Length--;
 			}
 			return sb.ToString();
+		}
+		public void ReverseDirection()
+		{
+			_reverseDirection = !_reverseDirection;
+		}
+		public List<LightNode> GetChildren() => _children;
+
+		public IEnumerator GetEnumerator()
+		{
+			return new LightNodeIterator(this, _reverseDirection);
+		}
+		public void Add(LightNode child)
+		{
+			AddChild(child);
 		}
 	}
 

--- a/lab3/Composite/classes/LightNodeIterator.cs
+++ b/lab3/Composite/classes/LightNodeIterator.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	using System.Collections.Generic;
+
+	public class LightNodeIterator : Iterator
+	{
+		private readonly LightElementNode _element;
+		private readonly List<LightNode> _children;
+		private readonly bool _reverse;
+		private int _position;
+
+		public LightNodeIterator(LightElementNode element, bool reverse = false)
+		{
+			_element = element;
+			_children = _element.GetChildren();
+			_reverse = reverse;
+			_position = reverse ? _children.Count : -1;
+		}
+
+		public override LightNode Current()
+		{
+			return _children[_position];
+		}
+
+		public override int Key()
+		{
+			return _position;
+		}
+
+		public override bool MoveNext()
+		{
+			int updatedPosition = _position + (_reverse ? -1 : 1);
+			if (updatedPosition >= 0 && updatedPosition < _children.Count)
+			{
+				_position = updatedPosition;
+				return true;
+			}
+			return false;
+		}
+
+		public override void Reset()
+		{
+			_position = _reverse ? _children.Count - 1 : 0;
+		}
+	}
+}

--- a/lab3/Composite/classes/NodeAggregate.cs
+++ b/lab3/Composite/classes/NodeAggregate.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	public interface NodeAggregate: IEnumerable
+	{
+		public abstract IEnumerator GetEnumerator();
+	}
+}


### PR DESCRIPTION
Патерн Iterator реалізовано для зручного послідовного обходу HTML-структури, зокрема вузлів `LightElementNode`, без необхідності знати їхню внутрішню реалізацію.

Реалізація:

+ Клас `LightElementNode` виступає агрегатом, що зберігає колекцію дочірніх вузлів (`_children`).

+ Для підтримки патерну додано окремий клас `Iterator`, який реалізує `IEnumerator`. Він інкапсулює логіку обходу елементів — як у прямому, так і в зворотному порядку.

+ Інтерфейс `NodeAggregate` (розширює `IEnumerable`) визначає контракт для всіх вузлів, які підтримують ітерацію.

+ LightElementNode реалізує `NodeAggregate`— це дозволяє клієнтському коду використовувати `foreach` для доступу до дочірніх вузлів без розкриття структури.

+ Метод `ReverseDirection()` дозволяє перемикати напрям обходу — це і є демонстрація розширюваності ітератора без зміни логіки клієнта.

+ Додано метод `Add(LightNode)` для підтримки collection initializer синтаксису, що дозволяє зручно вкладати вузли під час створення.