### PR TITLE
visitor implementation

### DIFF
--- a/lab3/Composite/classes/IVisitable.cs
+++ b/lab3/Composite/classes/IVisitable.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	public interface IVisitable
+	{
+		void Accept(IVisitor visitor);
+	}
+}

--- a/lab3/Composite/classes/IVisitor.cs
+++ b/lab3/Composite/classes/IVisitor.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	internal interface IVisitor
+	{
+		void Visit(LightElementNode elementNode);
+		void Visit(LightTextNode textNode);
+		void Visit(Image imageNode);
+	}
+}

--- a/lab3/Composite/classes/Image.cs
+++ b/lab3/Composite/classes/Image.cs
@@ -43,5 +43,10 @@ namespace Composite.classes
 		{
 			return OuterHTML;
 		}
+
+		public override void Accept(IVisitor visitor)
+		{
+			visitor.Visit(this);
+		}
 	}
 }

--- a/lab3/Composite/classes/LightElementNode.cs
+++ b/lab3/Composite/classes/LightElementNode.cs
@@ -9,18 +9,20 @@ namespace Composite.classes
 {
 	public class LightElementNode : LightNode, INodeAggregate
 	{
-		private string _tagName;
-		private bool _isBlock;
-		private bool _isSelfClosing;
-		private List<string> _cssClasses;
-		private List<LightNode> _children;
+		public string _tagName;
+		public bool _isBlock;
+		public bool _isSelfClosing;
+		public string? _id;
+		public List<string> _cssClasses;
+		public List<LightNode> _children;
 		private bool _reverseDirection = false;
 		private ILightNodeState _state = new EnabledState();
 
 		private Dictionary<string, List<Action>> _eventListeners = new Dictionary<string, List<Action>>();
 
-		public LightElementNode(string tagName, bool isBlock, bool isSelfClosing, List<string> cssClasses = null)
+		public LightElementNode(string tagName, bool isBlock, bool isSelfClosing, string id = null, List<string> cssClasses = null)
 		{
+			_id = id;
 			_tagName = tagName;
 			_isBlock = isBlock;
 			_isSelfClosing = isSelfClosing;
@@ -143,6 +145,11 @@ namespace Composite.classes
 		public void HandleEvent(string eventType)
 		{
 			_state.HandleEvent(this, eventType);
+		}
+
+		public override void Accept(IVisitor visitor)
+		{
+			visitor.Visit(this);
 		}
 	}
 }

--- a/lab3/Composite/classes/LightNode.cs
+++ b/lab3/Composite/classes/LightNode.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Composite.classes
 {
-	public abstract class LightNode
+	public abstract class LightNode : IVisitable
 	{
 		public abstract string OuterHTML { get; }
 		public abstract string InnerHTML { get; }
@@ -15,5 +15,6 @@ namespace Composite.classes
 		{
 			return OuterHTML; 
 		}
+		public abstract void Accept(IVisitor visitor);
 	}
 }

--- a/lab3/Composite/classes/LightTextNode.cs
+++ b/lab3/Composite/classes/LightTextNode.cs
@@ -22,5 +22,10 @@ namespace Composite.classes
 		{
 			return OuterHTML;
 		}
+
+		public override void Accept(IVisitor visitor)
+		{
+			visitor.Visit(this);
+		}
 	}
 }

--- a/lab3/Composite/classes/NodeCounterVisitor.cs
+++ b/lab3/Composite/classes/NodeCounterVisitor.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	public class NodeCounterVisitor : IVisitor
+	{
+		public int ElementNodeCount { get; private set; }
+		public int TextNodeCount { get; private set; }
+		public int ImageNodeCount { get; private set; }
+
+		public void Visit(LightElementNode elementNode)
+		{
+			ElementNodeCount++;
+			foreach (var child in elementNode.GetChildren())
+			{
+				child.Accept(this);
+			}
+		}
+
+		public void Visit(LightTextNode textNode)
+		{
+			TextNodeCount++;
+		}
+
+		public void Visit(Image imageNode)
+		{
+			ImageNodeCount++;
+		}
+
+		public string GetSummary()
+		{
+			return $"Element Nodes: {ElementNodeCount}, Text Nodes: {TextNodeCount}, Image Nodes: {ImageNodeCount}";
+		}
+	}
+}

--- a/lab3/Composite/classes/ValidationVisitor.cs
+++ b/lab3/Composite/classes/ValidationVisitor.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Composite.classes
+{
+	public class ValidationVisitor : IVisitor
+	{
+		private readonly List<string> _errors;
+		private readonly HashSet<string> _ids;
+		private readonly Stack<LightElementNode> _parentStack;
+
+		public ValidationVisitor()
+		{
+			_errors = new List<string>();
+			_ids = new HashSet<string>();
+			_parentStack = new Stack<LightElementNode>();
+		}
+
+		public void Visit(LightElementNode elementNode)
+		{
+			string tagName = elementNode._tagName;
+			bool isSelfClosing = elementNode._isSelfClosing;
+			string id = elementNode._id;
+
+			if (!string.IsNullOrEmpty(id))
+			{
+				if (_ids.Contains(id))
+				{
+					_errors.Add($"Duplicate ID '{id}' found in <{tagName}> element.");
+				}
+				else
+				{
+					_ids.Add(id);
+				}
+			}
+
+			if (!isSelfClosing && elementNode.ChildCount == 0)
+			{
+				_errors.Add($"Element <{tagName}> is empty and not self-closing.");
+			}
+
+			if (tagName == "li")
+			{
+				bool hasValidParent = _parentStack.Any() &&
+					  (_parentStack.Peek() as LightElementNode)?._tagName.ToLower() is "ul" or "ol";
+
+				if (!hasValidParent)
+				{
+					_errors.Add($"<li> element is not nested within a <ul> or <ol> parent.");
+				}
+			}
+
+			_parentStack.Push(elementNode);
+			foreach (var child in elementNode.GetChildren())
+			{
+				child.Accept(this);
+			}
+			_parentStack.Pop();
+		}
+
+		public void Visit(LightTextNode textNode)
+		{
+			if (string.IsNullOrWhiteSpace(textNode.OuterHTML))
+			{
+				_errors.Add("Text node contains empty or whitespace content.");
+			}
+		}
+
+		public void Visit(Image imageNode)
+		{
+			string id = imageNode.GetType().GetField("_id", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)?.GetValue(imageNode)?.ToString() ?? "";
+			if (!string.IsNullOrEmpty(id))
+			{
+				if (_ids.Contains(id))
+				{
+					_errors.Add($"Duplicate ID '{id}' found in <img> element with src='{imageNode.Href}'.");
+				}
+				else
+				{
+					_ids.Add(id);
+				}
+			}
+		}
+
+		public string GetValidationSummary()
+		{
+			if (_errors.Count == 0)
+			{
+				return "No validation errors found.";
+			}
+			return $"Found {_errors.Count} validation error(s):\n{string.Join("\n", _errors)}";
+		}
+	}
+}


### PR DESCRIPTION
Патерн Visitor використовується для виконання операцій над елементами складної структури об’єктів (у даному випадку, ієрархії LightNode) без модифікації їхніх класів. Він дозволяє відокремити алгоритм від структури даних, додаючи нові операції через створення нових класів відвідувачів. У наданий код реалізовано підтримку патерну Відвідувач для обробки об’єктів LightElementNode, LightTextNode та Image.

+ IVisitable: Визначає метод Accept(IVisitor visitor), який дозволяє кожному елементу структури приймати відвідувача. Цей інтерфейс реалізується абстрактним класом LightNode та його похідними класами (LightElementNode, LightTextNode, Image).
+ IVisitor: Визначає методи Visit для кожного типу вузла (Visit(LightElementNode), Visit(LightTextNode), Visit(Image)). Кожен конкретний відвідувач реалізує ці методи для виконання специфічних операцій.
+ NodeCounterVisitor: Підраховує кількість вузлів кожного типу (елементи, текстові вузли, зображення). Для LightElementNode рекурсивно обходить дітей, інкрементуючи лічильники для кожного типу вузла.
+ ValidationVisitor: Валідує структуру HTML, перевіряючи:
    + Правильність вкладеності (наприклад, `<li>` лише всередині `<ul>` або `<ol>`).
    + Наявність порожніх елементів, які не є самозакривними.
    + Унікальність атрибутів id у вузлах.